### PR TITLE
Prepare v0.5.0-beta release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,18 @@
 name: Build
 
 on:
+  pull_request:
+    branches:
+      - main
+
   push:
     branches:
+      - main
       - dev
     tags:
       - 'v*'
+
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Configure CMake
-      run: cmake -S . -B build
+      run: cmake -S . -B build -A x64
 
     - name: Build
       run: cmake --build build --config Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Project Overview
+
+RedLight is a Windows C++/Win32 project intended to provide a strict red-only display filter. The core behavior is not a translucent red tint. It should transform display output so that black remains black, white becomes pure red, and green/blue output is eliminated.
+
+Do not replace the core behavior with a translucent overlay unless explicitly instructed.
+
+## Development Guidance
+
+- Keep changes small, focused, and reviewable.
+- Prefer native C++/Win32 unless explicitly instructed otherwise.
+- Preserve the strict red-only output requirement:
+  - Black remains black.
+  - White becomes pure red.
+  - Green and blue output should be eliminated.
+- Treat display-affecting code as safety-sensitive.
+- Check Win32 API return values.
+- Avoid silently changing internal application state after failed Win32 API calls.
+- Use diagnostics and logging for display backend changes.
+- Do not perform broad rewrites unless the task explicitly asks for one.
+
+## Build Instructions
+
+Use the following commands to build the project:
+
+```sh
+cmake -S . -B build && cmake --build build --config Release
+```
+
+## Display-Affecting Changes
+
+Any change that affects display output, display state, color transformation, gamma ramps, monitor handling, recovery behavior, or related Win32 display APIs should be handled carefully.
+
+For display-affecting changes:
+
+- Include diagnostics or logging where appropriate.
+- Ensure failure states are visible and recoverable.
+- Restore prior display state where possible.
+- Do not report the filter as active unless the display backend call actually succeeded.
+- Include manual Windows test notes in the PR summary.
+
+Manual test notes should cover, when relevant:
+
+- Enabling and disabling the red-only filter.
+- Confirming black remains black and white becomes pure red.
+- Confirming green and blue output are eliminated.
+- Normal app exit and display restoration.
+- Failure/recovery behavior.
+- Multi-monitor behavior.
+- Sleep/wake, lock/unlock, display hotplug, or display settings changes if the change touches those areas.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Do not replace the core behavior with a translucent overlay unless explicitly in
 
 - Keep changes small, focused, and reviewable.
 - Prefer native C++/Win32 unless explicitly instructed otherwise.
+- Update `CHANGELOG.md` under `[Unreleased]` for user-visible changes, display backend changes, release-related changes, and behavior changes.
+- Add a changelog entry for internal refactors when they affect safety, restore behavior, backend selection, diagnostics, or user-visible reliability.
 - Preserve the strict red-only output requirement:
   - Black remains black.
   - White becomes pure red.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.5.0-beta] - 2026-05-07
+
+### Added
 - Added an experimental Magnification API red-filter probe.
 - Added a Magnification API display backend as the preferred RedLight backend.
 - Added a DisplayFilter abstraction for display backend implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kept the legacy gamma-ramp backend as a fallback.
 - Added lightweight diagnostics logging to `%LOCALAPPDATA%\\RedLight\\redlight.log`.
 - Added a command-line display reset mode for `--restore` and `--reset-display`.
+- Added startup diagnostics log rotation for `%LOCALAPPDATA%\\RedLight\\redlight.log` with up to three archived logs.
 
 ### Changed
 - Refactored the gamma-ramp implementation into GammaRampFilter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Magnification API display backend as the preferred RedLight backend.
 - Added a DisplayFilter abstraction for display backend implementations.
 - Kept the legacy gamma-ramp backend as a fallback.
+- Added lightweight diagnostics logging to `%LOCALAPPDATA%\\RedLight\\redlight.log`.
+- Added a command-line display reset mode for `--restore` and `--reset-display`.
 
 ### Changed
 - Refactored the gamma-ramp implementation into GammaRampFilter.
 - Updated the tray app to select the Magnification backend first and fall back to gamma ramp if needed.
+- Added startup and shutdown diagnostics, backend selection logging, and toggle/reset logging.
 
 ### Fixed
 - Improved display backend state handling so active state is only changed after successful backend calls.
 - Improved restore behavior by preserving and restoring the previous Magnification color matrix.
+- Added a best-effort Magnification restore path for display recovery without starting the tray UI.
+- Updated reset mode so `--restore` and `--reset-display` can ask a running tray instance to restore the active display filter.
 
 ### Tested
 - Verified Windows x64 build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Added an experimental Magnification API red-filter probe.
+- Added a Magnification API display backend as the preferred RedLight backend.
+- Added a DisplayFilter abstraction for display backend implementations.
+- Kept the legacy gamma-ramp backend as a fallback.
+
+### Changed
+- Refactored the gamma-ramp implementation into GammaRampFilter.
+- Updated the tray app to select the Magnification backend first and fall back to gamma ramp if needed.
+
+### Fixed
+- Improved display backend state handling so active state is only changed after successful backend calls.
+- Improved restore behavior by preserving and restoring the previous Magnification color matrix.
+
+### Tested
+- Verified Windows x64 build.
+- Verified tray toggle behavior.
+- Verified exit restoration.
+- Verified repeated enable/disable behavior.
+- Verified right-click Toggle ON/off behavior.
+- Verified MagRedProbe still builds/runs/restores.
+- Verified second-monitor behavior with the Magnification backend.
+
 ## [0.4.0-beta] - 2024-04-26
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable(RedLight WIN32
+    src/Diagnostics.cpp
+    src/Diagnostics.h
     src/main.cpp
     src/DisplayFilter.h
     src/GammaRampFilter.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,12 @@ add_executable(RedLight WIN32
     src/DisplayFilter.h
     src/GammaRampFilter.h
     src/GammaRampFilter.cpp
+    src/MagnificationFilter.h
+    src/MagnificationFilter.cpp
     resources/app.rc
 )
 
-target_link_libraries(RedLight PRIVATE user32 gdi32 Shell32)
+target_link_libraries(RedLight PRIVATE user32 gdi32 Shell32 Magnification)
 
 set_target_properties(RedLight PROPERTIES
     LINK_FLAGS "/SUBSYSTEM:WINDOWS"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(RedLight VERSION 0.4.0)
+project(RedLight VERSION 0.5.0)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,13 @@ project(RedLight VERSION 0.4.0)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-add_executable(RedLight WIN32 src/main.cpp resources/app.rc)
+add_executable(RedLight WIN32
+    src/main.cpp
+    src/DisplayFilter.h
+    src/GammaRampFilter.h
+    src/GammaRampFilter.cpp
+    resources/app.rc
+)
 
 target_link_libraries(RedLight PRIVATE user32 gdi32 Shell32)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,8 @@ target_link_libraries(RedLight PRIVATE user32 gdi32 Shell32)
 set_target_properties(RedLight PROPERTIES
     LINK_FLAGS "/SUBSYSTEM:WINDOWS"
 )
+
+if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+    add_executable(MagRedProbe experiments/MagRedProbe.cpp)
+    target_link_libraries(MagRedProbe PRIVATE Magnification)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # RedLight
-RedLight is a lightweight Windows tray application that applies a red filter to your display. This application operates from the system tray, allowing users to easily toggle the red filter on and off with one click.
+RedLight is a lightweight Windows tray application that applies a strict red-only display filter. It is not a translucent tint. The app runs from the system tray, allowing users to easily toggle the filter on and off with one click.
 
 ## Features
 - **Toggle Red Filter**: Quickly enable or disable the red filter directly from the system tray.
 - **Minimal Resource Usage**: Runs quietly in the background with essentially no impact on system performance.
+
+## Visual Behavior
+RedLight is intended to transform display output as follows:
+- Black stays black.
+- White becomes pure red.
+- Red stays red.
+- Green and blue output are eliminated.
+
+## Architecture
+v0.5.0-beta uses the Windows Magnification API full-screen color transform as the preferred backend.
+The legacy gamma-ramp backend is retained as a fallback.
 
 ## Installation
 To install RedLight, follow these steps:
@@ -20,18 +31,24 @@ After starting RedLight, an icon will appear in the system tray.
   - **Exit**: Quit the application.
 
 ## Important Notes
-* This application will conflict with other apps/features that change your screen color temperature, such as f.lux or the Windows Night Light feature. If you want to use RedLight, you should close or disable any other similar apps to avoid unexpected behavior.
-* RedLight is provided as-is and without any warranty of any kind. Although the code is simple and straightforward, you are still advised to use at your own risk!
+* This application may conflict with other apps/features that change display color, such as f.lux, Windows Night Light, HDR/color calibration settings, GPU color controls, or similar display-color tools. If you want to use RedLight, you should close or disable similar apps/features to avoid unexpected behavior.
+* RedLight is provided as-is and without any warranty of any kind. Although the code is simple and straightforward, you are still advised to use it at your own risk!
+
+## Troubleshooting
+* Log file: `%LOCALAPPDATA%\RedLight\redlight.log`
+* Reset commands:
+  * `RedLight.exe --restore`
+  * `RedLight.exe --reset-display`
+* Reset mode can ask a running tray instance to restore the display before falling back to direct recovery.
 
 ## Building from Source
-You can compile this C++ code using any modern C++ compiler such as MSVC or g++, as long as the standard is C++11 or newer.
-This repository provides a basic CMake configuration that can be  used to build RedLight.exe from source using MSVC.
-To use the provided CMake configuration, Ensure you have CMake installed and configured on your system. Follow these steps to build RedLight from source:
+RedLight is built and tested as a Windows x64 application. Use Visual Studio 2022 Build Tools or Visual Studio 2022 with the C++ toolchain installed.
 
 ### Prerequisites
 - Windows OS
 - CMake 3.20 or higher
-- Visual Studio 2019 or later (with C++ toolchain)
+- Visual Studio 2022 Build Tools or Visual Studio 2022
+- x64 C++ toolchain
 
 ### Build Instructions
 1. Clone the repository:
@@ -41,13 +58,15 @@ To use the provided CMake configuration, Ensure you have CMake installed and con
    ```
 2. Run CMake to generate the build configuration:
    ```
-   cmake -S . -B build
+   cmake -S . -B build -A x64
    ```
 3. Build the project:
    ```
    cmake --build build --config Release
    ```
-4. You will find the application built in `Release\RedLight.exe`
+4. The release artifact is expected at `build\Release\RedLight.exe`
+
+Local testing passed on a Windows 10 x64 system with two monitors.
 
 ## Contributing
 Contributions are welcome! Feel free to open pull requests or issues to suggest improvements or add new features.
@@ -56,5 +75,6 @@ Contributions are welcome! Feel free to open pull requests or issues to suggest 
 RedLight is open source software [licensed as GPLv3](LICENSE).
 
 ## Acknowledgments
-- Gamma ramp manipulation uses system APIs for color adjustment on Windows.
+- Windows Magnification API full-screen color transform is used as the preferred display backend.
+- Gamma ramp manipulation remains available as a fallback display backend on Windows.
 - Icon and design resources were custom made for this project using Adobe Photoshop and ImageMagick.

--- a/docs/magnification-probe.md
+++ b/docs/magnification-probe.md
@@ -1,0 +1,11 @@
+# Magnification Probe
+
+`MagRedProbe` is a Windows-only experimental console executable for checking whether the Magnification API can replace the current gamma-ramp backend.
+
+Manual test steps:
+
+1. Build on Windows x64 and run `MagRedProbe.exe`.
+1. Confirm the red-only matrix is applied.
+1. Verify black stays black, white becomes pure red, and green/blue content lose their non-red output.
+1. Press Enter to restore the previous color matrix and exit.
+1. Confirm the display returns to normal after exit.

--- a/experiments/MagRedProbe.cpp
+++ b/experiments/MagRedProbe.cpp
@@ -1,0 +1,127 @@
+#include <windows.h>
+#include <magnification.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+MAGCOLOREFFECT kIdentityEffect = {{
+    {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 1.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 1.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 1.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
+}};
+
+MAGCOLOREFFECT kRedOnlyEffect = {{
+    {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 1.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
+}};
+
+MAGCOLOREFFECT g_restoreEffect = kIdentityEffect;
+bool g_hasRestoreEffect = false;
+bool g_magInitialized = false;
+std::atomic<bool> g_cleanupStarted{false};
+
+template <typename Fn>
+auto LogApiCall(const char* name, Fn&& fn) -> decltype(fn()) {
+    SetLastError(0);
+    const auto result = fn();
+    const DWORD error = GetLastError();
+    std::printf("%s => %d, GetLastError=%lu\n", name, static_cast<int>(result), static_cast<unsigned long>(error));
+    return result;
+}
+
+void PrintPrompt() {
+    std::puts("Press Enter to restore the previous color matrix and exit.");
+}
+
+void RestoreDisplayState() {
+    bool expected = false;
+    if (!g_cleanupStarted.compare_exchange_strong(expected, true)) {
+        return;
+    }
+
+    if (g_magInitialized) {
+        MAGCOLOREFFECT* effect = g_hasRestoreEffect ? &g_restoreEffect : &kIdentityEffect;
+        const BOOL restored = LogApiCall("MagSetFullscreenColorEffect(restore)", [effect]() {
+            return MagSetFullscreenColorEffect(effect);
+        });
+        if (!restored) {
+            std::puts("Failed to restore the prior color matrix.");
+        }
+    }
+
+    if (g_magInitialized) {
+        const BOOL uninitialized = LogApiCall("MagUninitialize", []() {
+            return MagUninitialize();
+        });
+        if (!uninitialized) {
+            std::puts("MagUninitialize reported failure.");
+        }
+        g_magInitialized = false;
+    }
+}
+
+BOOL WINAPI ConsoleCtrlHandler(DWORD ctrlType) {
+    switch (ctrlType) {
+    case CTRL_C_EVENT:
+    case CTRL_BREAK_EVENT:
+    case CTRL_CLOSE_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+        std::puts("Console shutdown requested; attempting cleanup.");
+        RestoreDisplayState();
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::puts("MagRedProbe starting.");
+
+    (void)LogApiCall("SetConsoleCtrlHandler", []() {
+        return SetConsoleCtrlHandler(ConsoleCtrlHandler, TRUE);
+    });
+
+    const BOOL initialized = LogApiCall("MagInitialize", []() {
+        return MagInitialize();
+    });
+    if (!initialized) {
+        std::puts("MagInitialize failed; exiting without applying a color effect.");
+        return EXIT_FAILURE;
+    }
+    g_magInitialized = true;
+
+    const BOOL previousCaptured = LogApiCall("MagGetFullscreenColorEffect", []() {
+        return MagGetFullscreenColorEffect(&g_restoreEffect);
+    });
+    g_hasRestoreEffect = previousCaptured != FALSE;
+    if (!g_hasRestoreEffect) {
+        g_restoreEffect = kIdentityEffect;
+        std::puts("MagGetFullscreenColorEffect failed; identity will be used as the fallback restore matrix.");
+    }
+
+    const BOOL redApplied = LogApiCall("MagSetFullscreenColorEffect(red-only)", []() {
+        return MagSetFullscreenColorEffect(&kRedOnlyEffect);
+    });
+    if (!redApplied) {
+        std::puts("Failed to apply the red-only matrix; attempting cleanup.");
+    } else {
+        PrintPrompt();
+        (void)std::getchar();
+    }
+
+    RestoreDisplayState();
+
+    std::puts("MagRedProbe finished.");
+    return redApplied ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/Diagnostics.cpp
+++ b/src/Diagnostics.cpp
@@ -1,0 +1,142 @@
+#include "Diagnostics.h"
+
+#include <windows.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+namespace {
+
+HANDLE g_logFile = INVALID_HANDLE_VALUE;
+bool g_initialized = false;
+SRWLOCK g_lock = SRWLOCK_INIT;
+
+std::string BuildLogPath() {
+    char localAppData[32768] = {};
+    const DWORD length = GetEnvironmentVariableA("LOCALAPPDATA", localAppData, static_cast<DWORD>(sizeof(localAppData)));
+    if (length == 0 || length >= sizeof(localAppData)) {
+        return {};
+    }
+
+    std::string directory = localAppData;
+    directory += "\\RedLight";
+
+    if (!CreateDirectoryA(directory.c_str(), NULL)) {
+        const DWORD error = GetLastError();
+        if (error != ERROR_ALREADY_EXISTS) {
+            return {};
+        }
+    }
+
+    directory += "\\redlight.log";
+    return directory;
+}
+
+std::string BuildTimestamp() {
+    SYSTEMTIME st = {};
+    GetLocalTime(&st);
+
+    char timestamp[64] = {};
+    std::snprintf(timestamp, sizeof(timestamp), "%04u-%02u-%02u %02u:%02u:%02u.%03u",
+        static_cast<unsigned>(st.wYear),
+        static_cast<unsigned>(st.wMonth),
+        static_cast<unsigned>(st.wDay),
+        static_cast<unsigned>(st.wHour),
+        static_cast<unsigned>(st.wMinute),
+        static_cast<unsigned>(st.wSecond),
+        static_cast<unsigned>(st.wMilliseconds));
+    return timestamp;
+}
+
+void WriteLine(const char* message) {
+    std::string line = BuildTimestamp();
+    line += " ";
+    line += message ? message : "";
+    line += "\r\n";
+
+    OutputDebugStringA(line.c_str());
+
+    if (g_logFile == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    AcquireSRWLockExclusive(&g_lock);
+    DWORD written = 0;
+    (void)WriteFile(g_logFile, line.c_str(), static_cast<DWORD>(line.size()), &written, NULL);
+    ReleaseSRWLockExclusive(&g_lock);
+}
+
+}  // namespace
+
+namespace Diagnostics {
+
+void Initialize() {
+    if (g_initialized) {
+        return;
+    }
+
+    const std::string path = BuildLogPath();
+    if (!path.empty()) {
+        g_logFile = CreateFileA(
+            path.c_str(),
+            FILE_APPEND_DATA,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            NULL,
+            OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL,
+            NULL
+        );
+        if (g_logFile == INVALID_HANDLE_VALUE) {
+            OutputDebugStringA("RedLight: diagnostics log file unavailable; continuing with OutputDebugStringA only.\n");
+        }
+    }
+
+    g_initialized = true;
+}
+
+void Log(const char* message) {
+    if (!message) {
+        return;
+    }
+
+    if (!g_initialized) {
+        OutputDebugStringA(message);
+        OutputDebugStringA("\n");
+        return;
+    }
+
+    WriteLine(message);
+}
+
+void LogFormat(const char* format, ...) {
+    if (!format) {
+        return;
+    }
+
+    char buffer[1024] = {};
+    va_list args;
+    va_start(args, format);
+    (void)vsnprintf_s(buffer, sizeof(buffer), _TRUNCATE, format, args);
+    va_end(args);
+
+    Log(buffer);
+}
+
+void Shutdown() {
+    if (!g_initialized) {
+        return;
+    }
+
+    if (g_logFile != INVALID_HANDLE_VALUE) {
+        AcquireSRWLockExclusive(&g_lock);
+        (void)FlushFileBuffers(g_logFile);
+        (void)CloseHandle(g_logFile);
+        g_logFile = INVALID_HANDLE_VALUE;
+        ReleaseSRWLockExclusive(&g_lock);
+    }
+
+    g_initialized = false;
+}
+
+}  // namespace Diagnostics

--- a/src/Diagnostics.cpp
+++ b/src/Diagnostics.cpp
@@ -12,7 +12,9 @@ HANDLE g_logFile = INVALID_HANDLE_VALUE;
 bool g_initialized = false;
 SRWLOCK g_lock = SRWLOCK_INIT;
 
-std::string BuildLogPath() {
+constexpr ULONGLONG kMaxLogSizeBytes = 1ull << 20;
+
+std::string BuildLogDirectory() {
     char localAppData[32768] = {};
     const DWORD length = GetEnvironmentVariableA("LOCALAPPDATA", localAppData, static_cast<DWORD>(sizeof(localAppData)));
     if (length == 0 || length >= sizeof(localAppData)) {
@@ -29,7 +31,17 @@ std::string BuildLogPath() {
         }
     }
 
-    directory += "\\redlight.log";
+    return directory;
+}
+
+std::string BuildLogPath(const char* fileName) {
+    std::string directory = BuildLogDirectory();
+    if (directory.empty()) {
+        return {};
+    }
+
+    directory += "\\";
+    directory += fileName ? fileName : "";
     return directory;
 }
 
@@ -47,6 +59,90 @@ std::string BuildTimestamp() {
         static_cast<unsigned>(st.wSecond),
         static_cast<unsigned>(st.wMilliseconds));
     return timestamp;
+}
+
+void WriteDebugFailure(const char* action, const std::string& path, DWORD error) {
+    char buffer[512] = {};
+    std::snprintf(buffer, sizeof(buffer), "RedLight: diagnostics %s failed for %s (error %lu)\n",
+        action ? action : "operation",
+        path.c_str(),
+        static_cast<unsigned long>(error));
+    OutputDebugStringA(buffer);
+}
+
+bool IsLogTooLarge(const std::string& path) {
+    WIN32_FILE_ATTRIBUTE_DATA data = {};
+    if (!GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &data)) {
+        return false;
+    }
+
+    const ULONGLONG size = (static_cast<ULONGLONG>(data.nFileSizeHigh) << 32) |
+        static_cast<ULONGLONG>(data.nFileSizeLow);
+    return size > kMaxLogSizeBytes;
+}
+
+void BestEffortDeleteFile(const std::string& path) {
+    if (!DeleteFileA(path.c_str())) {
+        const DWORD error = GetLastError();
+        if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND) {
+            WriteDebugFailure("delete", path, error);
+        }
+    }
+}
+
+void BestEffortMoveFile(const std::string& from, const std::string& to) {
+    if (!MoveFileExA(from.c_str(), to.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+        const DWORD error = GetLastError();
+        if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+            return;
+        }
+
+        std::string path = from;
+        path += " -> ";
+        path += to;
+        WriteDebugFailure("rename", path, error);
+    }
+}
+
+void RotateLogsIfNeeded() {
+    const std::string logPath = BuildLogPath("redlight.log");
+    if (logPath.empty() || !IsLogTooLarge(logPath)) {
+        return;
+    }
+
+    const std::string log1Path = BuildLogPath("redlight.1.log");
+    const std::string log2Path = BuildLogPath("redlight.2.log");
+    const std::string log3Path = BuildLogPath("redlight.3.log");
+    if (log1Path.empty() || log2Path.empty() || log3Path.empty()) {
+        return;
+    }
+
+    BestEffortDeleteFile(log3Path);
+    BestEffortMoveFile(log2Path, log3Path);
+    BestEffortMoveFile(log1Path, log2Path);
+    BestEffortMoveFile(logPath, log1Path);
+}
+
+void OpenLogFile() {
+    const std::string path = BuildLogPath("redlight.log");
+    if (path.empty()) {
+        return;
+    }
+
+    RotateLogsIfNeeded();
+
+    g_logFile = CreateFileA(
+        path.c_str(),
+        FILE_APPEND_DATA,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        NULL,
+        OPEN_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        NULL
+    );
+    if (g_logFile == INVALID_HANDLE_VALUE) {
+        OutputDebugStringA("RedLight: diagnostics log file unavailable; continuing with OutputDebugStringA only.\n");
+    }
 }
 
 void WriteLine(const char* message) {
@@ -76,22 +172,7 @@ void Initialize() {
         return;
     }
 
-    const std::string path = BuildLogPath();
-    if (!path.empty()) {
-        g_logFile = CreateFileA(
-            path.c_str(),
-            FILE_APPEND_DATA,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            NULL,
-            OPEN_ALWAYS,
-            FILE_ATTRIBUTE_NORMAL,
-            NULL
-        );
-        if (g_logFile == INVALID_HANDLE_VALUE) {
-            OutputDebugStringA("RedLight: diagnostics log file unavailable; continuing with OutputDebugStringA only.\n");
-        }
-    }
-
+    OpenLogFile();
     g_initialized = true;
 }
 

--- a/src/Diagnostics.h
+++ b/src/Diagnostics.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Diagnostics {
+
+void Initialize();
+void Log(const char* message);
+void LogFormat(const char* format, ...);
+void Shutdown();
+
+}  // namespace Diagnostics

--- a/src/DisplayFilter.h
+++ b/src/DisplayFilter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class DisplayFilter {
+public:
+    virtual ~DisplayFilter() = default;
+
+    virtual bool initialize() = 0;
+    virtual bool enable() = 0;
+    virtual bool disable() = 0;
+    virtual bool isActive() const = 0;
+    virtual void shutdown() = 0;
+    virtual const char* name() const = 0;
+};

--- a/src/GammaRampFilter.cpp
+++ b/src/GammaRampFilter.cpp
@@ -1,4 +1,5 @@
 #include "GammaRampFilter.h"
+#include "Diagnostics.h"
 
 #include <cstdio>
 
@@ -28,6 +29,7 @@ bool GammaRampFilter::initialize() {
     hdc_ = GetDC(NULL);
     if (!hdc_) {
         SetError("GetDC", GetLastError());
+        Diagnostics::LogFormat("%s initialization failed.", kFilterName);
         return false;
     }
 
@@ -35,6 +37,7 @@ bool GammaRampFilter::initialize() {
         SetError("GetDeviceGammaRamp", GetLastError());
         ReleaseDC(NULL, hdc_);
         hdc_ = NULL;
+        Diagnostics::LogFormat("%s initialization failed.", kFilterName);
         return false;
     }
 
@@ -42,6 +45,7 @@ bool GammaRampFilter::initialize() {
     initialized_ = true;
     active_ = false;
     lastError_[0] = '\0';
+    Diagnostics::LogFormat("%s initialization succeeded.", kFilterName);
     return true;
 }
 
@@ -60,6 +64,7 @@ bool GammaRampFilter::enable() {
     }
 
     active_ = true;
+    Diagnostics::LogFormat("%s enable succeeded.", kFilterName);
     return true;
 }
 
@@ -78,6 +83,7 @@ bool GammaRampFilter::disable() {
     }
 
     active_ = false;
+    Diagnostics::LogFormat("%s disable succeeded.", kFilterName);
     return true;
 }
 
@@ -91,8 +97,9 @@ void GammaRampFilter::shutdown() {
     }
 
     if (hdc_) {
+        Diagnostics::LogFormat("%s shutdown restore attempt.", kFilterName);
         if (!SetGammaRamp(originalGammaRamp_, "shutdown restore")) {
-            OutputDebugStringA("GammaRampFilter: shutdown restore failed; display state may not have been restored.\n");
+            Diagnostics::Log("GammaRampFilter: shutdown restore failed; display state may not have been restored.");
         } else {
             active_ = false;
         }
@@ -115,7 +122,7 @@ void GammaRampFilter::SetError(const char* action, DWORD error) {
         kFilterName,
         action,
         static_cast<unsigned long>(error));
-    OutputDebugStringA(lastError_);
+    Diagnostics::LogFormat("%s: %s failed (GetLastError=%lu)", kFilterName, action, static_cast<unsigned long>(error));
 }
 
 bool GammaRampFilter::SetGammaRamp(WORD ramp[3][256], const char* action) {

--- a/src/GammaRampFilter.cpp
+++ b/src/GammaRampFilter.cpp
@@ -1,0 +1,142 @@
+#include "GammaRampFilter.h"
+
+#include <cstdio>
+
+namespace {
+
+constexpr const char* kFilterName = "GammaRampFilter";
+
+}
+
+GammaRampFilter::GammaRampFilter()
+    : hdc_(NULL),
+      initialized_(false),
+      active_(false),
+      originalGammaRamp_{},
+      redGammaRamp_{},
+      lastError_{} {}
+
+GammaRampFilter::~GammaRampFilter() {
+    shutdown();
+}
+
+bool GammaRampFilter::initialize() {
+    if (initialized_) {
+        return true;
+    }
+
+    hdc_ = GetDC(NULL);
+    if (!hdc_) {
+        SetError("GetDC", GetLastError());
+        return false;
+    }
+
+    if (!GetDeviceGammaRamp(hdc_, originalGammaRamp_)) {
+        SetError("GetDeviceGammaRamp", GetLastError());
+        ReleaseDC(NULL, hdc_);
+        hdc_ = NULL;
+        return false;
+    }
+
+    BuildRedRamp();
+    initialized_ = true;
+    active_ = false;
+    lastError_[0] = '\0';
+    return true;
+}
+
+bool GammaRampFilter::enable() {
+    if (!initialized_) {
+        SetError("enable before initialize", ERROR_INVALID_HANDLE);
+        return false;
+    }
+
+    if (active_) {
+        return true;
+    }
+
+    if (!SetGammaRamp(redGammaRamp_, "SetDeviceGammaRamp(red)")) {
+        return false;
+    }
+
+    active_ = true;
+    return true;
+}
+
+bool GammaRampFilter::disable() {
+    if (!initialized_) {
+        SetError("disable before initialize", ERROR_INVALID_HANDLE);
+        return false;
+    }
+
+    if (!active_) {
+        return true;
+    }
+
+    if (!SetGammaRamp(originalGammaRamp_, "SetDeviceGammaRamp(restore)")) {
+        return false;
+    }
+
+    active_ = false;
+    return true;
+}
+
+bool GammaRampFilter::isActive() const {
+    return active_;
+}
+
+void GammaRampFilter::shutdown() {
+    if (!initialized_) {
+        return;
+    }
+
+    if (hdc_) {
+        if (!SetGammaRamp(originalGammaRamp_, "shutdown restore")) {
+            OutputDebugStringA("GammaRampFilter: shutdown restore failed; display state may not have been restored.\n");
+        } else {
+            active_ = false;
+        }
+
+        if (!ReleaseDC(NULL, hdc_)) {
+            SetError("ReleaseDC", GetLastError());
+        }
+        hdc_ = NULL;
+    }
+
+    initialized_ = false;
+}
+
+const char* GammaRampFilter::name() const {
+    return kFilterName;
+}
+
+void GammaRampFilter::SetError(const char* action, DWORD error) {
+    std::snprintf(lastError_, sizeof(lastError_), "%s: %s failed (GetLastError=%lu)\n",
+        kFilterName,
+        action,
+        static_cast<unsigned long>(error));
+    OutputDebugStringA(lastError_);
+}
+
+bool GammaRampFilter::SetGammaRamp(WORD ramp[3][256], const char* action) {
+    if (!hdc_) {
+        SetError(action, ERROR_INVALID_HANDLE);
+        return false;
+    }
+
+    if (!SetDeviceGammaRamp(hdc_, ramp)) {
+        SetError(action, GetLastError());
+        return false;
+    }
+
+    lastError_[0] = '\0';
+    return true;
+}
+
+void GammaRampFilter::BuildRedRamp() {
+    for (int i = 0; i < 256; ++i) {
+        redGammaRamp_[0][i] = static_cast<WORD>(i << 8);
+        redGammaRamp_[1][i] = 0;
+        redGammaRamp_[2][i] = 0;
+    }
+}

--- a/src/GammaRampFilter.h
+++ b/src/GammaRampFilter.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "DisplayFilter.h"
+
+#include <windows.h>
+
+class GammaRampFilter final : public DisplayFilter {
+public:
+    GammaRampFilter();
+    ~GammaRampFilter() override;
+
+    bool initialize() override;
+    bool enable() override;
+    bool disable() override;
+    bool isActive() const override;
+    void shutdown() override;
+    const char* name() const override;
+
+private:
+    void SetError(const char* action, DWORD error);
+    bool SetGammaRamp(WORD ramp[3][256], const char* action);
+    void BuildRedRamp();
+
+    HDC hdc_;
+    bool initialized_;
+    bool active_;
+    WORD originalGammaRamp_[3][256];
+    WORD redGammaRamp_[3][256];
+    char lastError_[256];
+};

--- a/src/MagnificationFilter.cpp
+++ b/src/MagnificationFilter.cpp
@@ -1,0 +1,148 @@
+#include "MagnificationFilter.h"
+
+#include <cstdio>
+
+namespace {
+
+constexpr const char* kFilterName = "MagnificationFilter";
+
+constexpr MAGCOLOREFFECT kIdentityEffect = {{
+    {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 1.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 1.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 1.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
+}};
+
+constexpr MAGCOLOREFFECT kRedOnlyEffect = {{
+    {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 1.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
+}};
+
+}  // namespace
+
+MagnificationFilter::MagnificationFilter()
+    : initialized_(false),
+      active_(false),
+      restoreEffect_(kIdentityEffect),
+      lastError_{} {}
+
+MagnificationFilter::~MagnificationFilter() {
+    shutdown();
+}
+
+bool MagnificationFilter::initialize() {
+    if (initialized_) {
+        return true;
+    }
+
+    if (!MagInitialize()) {
+        LogError("MagInitialize", GetLastError());
+        return false;
+    }
+
+    MAGCOLOREFFECT capturedEffect = {};
+    if (MagGetFullscreenColorEffect(&capturedEffect)) {
+        restoreEffect_ = capturedEffect;
+    } else {
+        LogError("MagGetFullscreenColorEffect", GetLastError());
+        restoreEffect_ = kIdentityEffect;
+        OutputDebugStringA("MagnificationFilter: using identity restore matrix because the previous full-screen color effect could not be captured.\n");
+    }
+
+    initialized_ = true;
+    active_ = false;
+    lastError_[0] = '\0';
+    return true;
+}
+
+bool MagnificationFilter::enable() {
+    if (!initialized_) {
+        LogError("enable before initialize", ERROR_INVALID_HANDLE);
+        return false;
+    }
+
+    if (active_) {
+        return true;
+    }
+
+    if (!SetColorEffect(kRedOnlyEffect, "MagSetFullscreenColorEffect(red-only)")) {
+        return false;
+    }
+
+    active_ = true;
+    return true;
+}
+
+bool MagnificationFilter::disable() {
+    if (!initialized_) {
+        LogError("disable before initialize", ERROR_INVALID_HANDLE);
+        return false;
+    }
+
+    if (!active_) {
+        return true;
+    }
+
+    if (!SetColorEffect(restoreEffect_, "MagSetFullscreenColorEffect(restore)")) {
+        return false;
+    }
+
+    active_ = false;
+    return true;
+}
+
+bool MagnificationFilter::isActive() const {
+    return active_;
+}
+
+void MagnificationFilter::shutdown() {
+    if (!initialized_) {
+        return;
+    }
+
+    if (active_) {
+        if (!SetColorEffect(restoreEffect_, "shutdown restore")) {
+            OutputDebugStringA("MagnificationFilter: shutdown restore failed; display state may not have been restored.\n");
+        } else {
+            active_ = false;
+        }
+    }
+
+    if (!MagUninitialize()) {
+        LogError("MagUninitialize", GetLastError());
+    }
+
+    initialized_ = false;
+}
+
+const char* MagnificationFilter::name() const {
+    return kFilterName;
+}
+
+void MagnificationFilter::LogError(const char* action, DWORD error) {
+    std::snprintf(lastError_, sizeof(lastError_), "%s: %s failed (GetLastError=%lu)\n",
+        kFilterName,
+        action,
+        static_cast<unsigned long>(error));
+    OutputDebugStringA(lastError_);
+}
+
+bool MagnificationFilter::SetColorEffect(const MAGCOLOREFFECT& effect, const char* action) {
+    if (!initialized_) {
+        LogError(action, ERROR_INVALID_HANDLE);
+        return false;
+    }
+
+    MAGCOLOREFFECT mutableEffect = effect;
+    if (!MagSetFullscreenColorEffect(&mutableEffect)) {
+        LogError(action, GetLastError());
+        return false;
+    }
+
+    lastError_[0] = '\0';
+    return true;
+}

--- a/src/MagnificationFilter.cpp
+++ b/src/MagnificationFilter.cpp
@@ -1,4 +1,5 @@
 #include "MagnificationFilter.h"
+#include "Diagnostics.h"
 
 #include <cstdio>
 
@@ -41,6 +42,7 @@ bool MagnificationFilter::initialize() {
 
     if (!MagInitialize()) {
         LogError("MagInitialize", GetLastError());
+        Diagnostics::LogFormat("%s initialization failed.", kFilterName);
         return false;
     }
 
@@ -50,12 +52,13 @@ bool MagnificationFilter::initialize() {
     } else {
         LogError("MagGetFullscreenColorEffect", GetLastError());
         restoreEffect_ = kIdentityEffect;
-        OutputDebugStringA("MagnificationFilter: using identity restore matrix because the previous full-screen color effect could not be captured.\n");
+        Diagnostics::Log("MagnificationFilter: using identity restore matrix because the previous full-screen color effect could not be captured.");
     }
 
     initialized_ = true;
     active_ = false;
     lastError_[0] = '\0';
+    Diagnostics::LogFormat("%s initialization succeeded.", kFilterName);
     return true;
 }
 
@@ -74,6 +77,7 @@ bool MagnificationFilter::enable() {
     }
 
     active_ = true;
+    Diagnostics::LogFormat("%s enable succeeded.", kFilterName);
     return true;
 }
 
@@ -92,6 +96,7 @@ bool MagnificationFilter::disable() {
     }
 
     active_ = false;
+    Diagnostics::LogFormat("%s disable succeeded.", kFilterName);
     return true;
 }
 
@@ -105,8 +110,9 @@ void MagnificationFilter::shutdown() {
     }
 
     if (active_) {
+        Diagnostics::LogFormat("%s shutdown restore attempt.", kFilterName);
         if (!SetColorEffect(restoreEffect_, "shutdown restore")) {
-            OutputDebugStringA("MagnificationFilter: shutdown restore failed; display state may not have been restored.\n");
+            Diagnostics::Log("MagnificationFilter: shutdown restore failed; display state may not have been restored.");
         } else {
             active_ = false;
         }
@@ -114,6 +120,8 @@ void MagnificationFilter::shutdown() {
 
     if (!MagUninitialize()) {
         LogError("MagUninitialize", GetLastError());
+    } else {
+        Diagnostics::LogFormat("%s shutdown completed.", kFilterName);
     }
 
     initialized_ = false;
@@ -128,7 +136,7 @@ void MagnificationFilter::LogError(const char* action, DWORD error) {
         kFilterName,
         action,
         static_cast<unsigned long>(error));
-    OutputDebugStringA(lastError_);
+    Diagnostics::LogFormat("%s: %s failed (GetLastError=%lu)", kFilterName, action, static_cast<unsigned long>(error));
 }
 
 bool MagnificationFilter::SetColorEffect(const MAGCOLOREFFECT& effect, const char* action) {

--- a/src/MagnificationFilter.h
+++ b/src/MagnificationFilter.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "DisplayFilter.h"
+
+#include <windows.h>
+#include <magnification.h>
+
+class MagnificationFilter final : public DisplayFilter {
+public:
+    MagnificationFilter();
+    ~MagnificationFilter() override;
+
+    bool initialize() override;
+    bool enable() override;
+    bool disable() override;
+    bool isActive() const override;
+    void shutdown() override;
+    const char* name() const override;
+
+private:
+    void LogError(const char* action, DWORD error);
+    bool SetColorEffect(const MAGCOLOREFFECT& effect, const char* action);
+
+    bool initialized_;
+    bool active_;
+    MAGCOLOREFFECT restoreEffect_;
+    char lastError_[256];
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,16 +2,16 @@
 #include <shellapi.h>
 #include <cstdio>
 
+#include "GammaRampFilter.h"
+
 #define WM_TRAYICON (WM_USER + 1)
 #define IDI_REDLIGHT_ICON 100
 #define ID_TRAY_TOGGLE 200
 #define ID_TRAY_ABOUT 201
 #define ID_TRAY_EXIT 202
 
-HDC hDC;
-WORD originalGammaRamp[3][256];
-WORD redGammaRamp[3][256];
-bool isRedlightActive = false;
+GammaRampFilter g_gammaRampFilter;
+DisplayFilter* g_displayFilter = &g_gammaRampFilter;
 NOTIFYICONDATA nid = {};
 
 void ToggleRedlight();
@@ -24,21 +24,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // silently exit multiple instances
     HANDLE hMutex = CreateMutex(NULL, TRUE, "Global\\RedLightApp");
+    if (!hMutex) {
+        return 1;
+    }
+
     if (GetLastError() == ERROR_ALREADY_EXISTS) {
+        CloseHandle(hMutex);
         return 1;
     }
 
-    hDC = GetDC(NULL);
-    if (!hDC) {
-        MessageBox(NULL, "Failed to get device context.", "Error", MB_ICONERROR);
+    if (!g_displayFilter->initialize()) {
+        CloseHandle(hMutex);
         return 1;
-    }
-
-    GetDeviceGammaRamp(hDC, originalGammaRamp); // store the original gamma ramp
-
-    for (int i = 0; i < 256; i++) {
-        redGammaRamp[0][i] = (WORD)(i << 8);
-        redGammaRamp[1][i] = redGammaRamp[2][i] = 0;
     }
 
     InitializeTrayIcon(hInstance);
@@ -49,8 +46,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         DispatchMessage(&msg);
     }
 
-    SetDeviceGammaRamp(hDC, originalGammaRamp); // restore the original gamma ramp
-    ReleaseDC(NULL, hDC);
+    g_displayFilter->shutdown();
 
     ReleaseMutex(hMutex);
     CloseHandle(hMutex);
@@ -63,13 +59,17 @@ void UpdateTrayIconTip(const char* tip) {
 }
 
 void ToggleRedlight() {
-    if (isRedlightActive) {
-        SetDeviceGammaRamp(hDC, originalGammaRamp);
+    if (g_displayFilter->isActive()) {
+        if (!g_displayFilter->disable()) {
+            OutputDebugStringA("RedLight: failed to disable red filter.\n");
+        }
     } else {
-        SetDeviceGammaRamp(hDC, redGammaRamp);
+        if (!g_displayFilter->enable()) {
+            OutputDebugStringA("RedLight: failed to enable red filter.\n");
+        }
     }
-    isRedlightActive = !isRedlightActive;
-    UpdateTrayIconTip(isRedlightActive ? "RedLight ON" : "RedLight off");
+
+    UpdateTrayIconTip(g_displayFilter->isActive() ? "RedLight ON" : "RedLight off");
 }
 
 void InitializeTrayIcon(HINSTANCE hInstance) {
@@ -92,7 +92,6 @@ void InitializeTrayIcon(HINSTANCE hInstance) {
 }
 
 void ShowAboutDialog(HWND parent) {
-    const HINSTANCE hInstance = GetModuleHandle(NULL);
     char aboutText[512];
     sprintf_s(aboutText, sizeof(aboutText), "RedLight v0.4.0-beta\n\ngithub.com/michaelmawhinney/redlight");
     const char* aboutTitle = "About";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,12 @@
 #include <shellapi.h>
 #include <cstdio>
 
+#include "Diagnostics.h"
 #include "GammaRampFilter.h"
 #include "MagnificationFilter.h"
 
 #define WM_TRAYICON (WM_USER + 1)
+#define WM_REDLIGHT_RESTORE (WM_APP + 1)
 #define IDI_REDLIGHT_ICON 100
 #define ID_TRAY_TOGGLE 200
 #define ID_TRAY_ABOUT 201
@@ -18,14 +20,12 @@ GammaRampFilter g_gammaRampFilter;
 DisplayFilter* g_displayFilter = &g_gammaRampFilter;
 NOTIFYICONDATA nid = {};
 
-void LogBackendMessage(const char* message, const char* backendName) {
-    char buffer[256];
-    sprintf_s(buffer, sizeof(buffer), "RedLight: %s (%s)\n", message, backendName);
-    OutputDebugStringA(buffer);
 }
 
-}
-
+bool ShouldRunResetMode();
+void LogSystemInfo();
+bool ResetDisplay();
+bool RequestRunningInstanceRestore(bool* handled);
 void ToggleRedlight();
 void UpdateTrayIconTip(const char* tip);
 void InitializeTrayIcon(HINSTANCE hInstance);
@@ -33,31 +33,57 @@ void ShowAboutDialog(HWND parent);
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
+    (void)hPrevInstance;
+    (void)lpCmdLine;
+    (void)nShowCmd;
+
+    Diagnostics::Initialize();
+    Diagnostics::Log("RedLight starting.");
+    LogSystemInfo();
+
+    if (ShouldRunResetMode()) {
+        const bool resetSucceeded = ResetDisplay();
+        Diagnostics::LogFormat("RedLight reset mode completed with %s.", resetSucceeded ? "success" : "failure");
+        Diagnostics::Log("RedLight exiting.");
+        Diagnostics::Shutdown();
+        return resetSucceeded ? 0 : 1;
+    }
 
     // silently exit multiple instances
     HANDLE hMutex = CreateMutex(NULL, TRUE, "Global\\RedLightApp");
     if (!hMutex) {
+        Diagnostics::LogFormat("CreateMutex failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
+        Diagnostics::Log("RedLight exiting.");
+        Diagnostics::Shutdown();
         return 1;
     }
 
     if (GetLastError() == ERROR_ALREADY_EXISTS) {
+        Diagnostics::Log("Another RedLight instance is already running.");
         CloseHandle(hMutex);
+        Diagnostics::Log("RedLight exiting.");
+        Diagnostics::Shutdown();
         return 1;
     }
 
     if (g_magnificationFilter.initialize()) {
         g_displayFilter = &g_magnificationFilter;
-        LogBackendMessage("using primary display backend", g_displayFilter->name());
+        Diagnostics::LogFormat("Selected backend: %s", g_displayFilter->name());
     } else {
-        OutputDebugStringA("RedLight: MagnificationFilter initialization failed; falling back to GammaRampFilter.\n");
+        Diagnostics::Log("MagnificationFilter initialization failed; falling back to GammaRampFilter.");
         if (!g_gammaRampFilter.initialize()) {
+            Diagnostics::Log("GammaRampFilter initialization failed.");
+            ReleaseMutex(hMutex);
             CloseHandle(hMutex);
+            Diagnostics::Log("RedLight exiting.");
+            Diagnostics::Shutdown();
             return 1;
         }
         g_displayFilter = &g_gammaRampFilter;
-        LogBackendMessage("using fallback display backend", g_displayFilter->name());
+        Diagnostics::LogFormat("Selected backend: %s", g_displayFilter->name());
     }
 
+    Diagnostics::LogFormat("Monitor count: %d", GetSystemMetrics(SM_CMONITORS));
     InitializeTrayIcon(hInstance);
 
     MSG msg = {};
@@ -67,10 +93,157 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     }
 
     g_displayFilter->shutdown();
+    Diagnostics::Log("RedLight exiting.");
 
     ReleaseMutex(hMutex);
     CloseHandle(hMutex);
+    Diagnostics::Shutdown();
     return 0;
+}
+
+bool ShouldRunResetMode() {
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    if (!argv) {
+        return false;
+    }
+
+    bool resetMode = false;
+    for (int i = 1; i < argc; ++i) {
+        if (lstrcmpiW(argv[i], L"--restore") == 0 || lstrcmpiW(argv[i], L"--reset-display") == 0) {
+            resetMode = true;
+            break;
+        }
+    }
+
+    LocalFree(argv);
+    return resetMode;
+}
+
+void LogSystemInfo() {
+    HMODULE ntdll = LoadLibraryA("ntdll.dll");
+    if (!ntdll) {
+        Diagnostics::Log("Windows version: unavailable.");
+        return;
+    }
+
+    struct RTL_OSVERSIONINFOW_LOCAL {
+        ULONG dwOSVersionInfoSize;
+        ULONG dwMajorVersion;
+        ULONG dwMinorVersion;
+        ULONG dwBuildNumber;
+        ULONG dwPlatformId;
+        WCHAR szCSDVersion[128];
+    } version = {};
+
+    using RtlGetVersionFn = LONG (WINAPI*)(RTL_OSVERSIONINFOW_LOCAL*);
+    auto rtlGetVersion = reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdll, "RtlGetVersion"));
+    if (!rtlGetVersion) {
+        FreeLibrary(ntdll);
+        Diagnostics::Log("Windows version: unavailable.");
+        return;
+    }
+
+    version.dwOSVersionInfoSize = sizeof(version);
+    if (rtlGetVersion(&version) == 0) {
+        Diagnostics::LogFormat("Windows version: %lu.%lu build %lu",
+            static_cast<unsigned long>(version.dwMajorVersion),
+            static_cast<unsigned long>(version.dwMinorVersion),
+            static_cast<unsigned long>(version.dwBuildNumber));
+    } else {
+        Diagnostics::Log("Windows version: unavailable.");
+    }
+
+    FreeLibrary(ntdll);
+}
+
+bool ResetDisplay() {
+    bool restoreHandledByRunningInstance = false;
+    if (RequestRunningInstanceRestore(&restoreHandledByRunningInstance)) {
+        Diagnostics::Log("Reset mode: running instance restore succeeded.");
+        return true;
+    }
+
+    if (restoreHandledByRunningInstance) {
+        Diagnostics::Log("Reset mode: running instance restore failed.");
+        return false;
+    }
+
+    constexpr MAGCOLOREFFECT kIdentityEffect = {{
+        {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+        {0.0f, 1.0f, 0.0f, 0.0f, 0.0f},
+        {0.0f, 0.0f, 1.0f, 0.0f, 0.0f},
+        {0.0f, 0.0f, 0.0f, 1.0f, 0.0f},
+        {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
+    }};
+
+    Diagnostics::Log("Reset mode: attempting Magnification API restore.");
+
+    if (!MagInitialize()) {
+        Diagnostics::LogFormat("Reset mode: MagInitialize failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
+        Diagnostics::Log("Reset mode: gamma-ramp reset not available without a saved ramp.");
+        return false;
+    }
+
+    Diagnostics::Log("Reset mode: MagInitialize succeeded.");
+
+    MAGCOLOREFFECT identity = kIdentityEffect;
+    const BOOL colorEffectReset = MagSetFullscreenColorEffect(&identity);
+    if (colorEffectReset) {
+        Diagnostics::Log("Reset mode: MagSetFullscreenColorEffect(identity) succeeded.");
+    } else {
+        Diagnostics::LogFormat("Reset mode: MagSetFullscreenColorEffect(identity) failed (GetLastError=%lu).",
+            static_cast<unsigned long>(GetLastError()));
+    }
+
+    if (!MagUninitialize()) {
+        Diagnostics::LogFormat("Reset mode: MagUninitialize failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
+    } else {
+        Diagnostics::Log("Reset mode: MagUninitialize succeeded.");
+    }
+
+    Diagnostics::Log("Reset mode: gamma-ramp reset not available without a saved ramp.");
+    return colorEffectReset != FALSE;
+}
+
+bool RequestRunningInstanceRestore(bool* handled) {
+    if (handled) {
+        *handled = false;
+    }
+
+    HWND trayWindow = FindWindowA("TrayOnlyClass", "RedLight");
+    if (!trayWindow) {
+        Diagnostics::Log("Reset mode: running tray window not found.");
+        return false;
+    }
+
+    if (handled) {
+        *handled = true;
+    }
+
+    Diagnostics::LogFormat("Reset mode: found running tray window (hwnd=%p).", static_cast<void*>(trayWindow));
+
+    DWORD_PTR restoreResult = FALSE;
+    const LRESULT messageResult = SendMessageTimeoutA(
+        trayWindow,
+        WM_REDLIGHT_RESTORE,
+        0,
+        0,
+        SMTO_ABORTIFHUNG,
+        3000,
+        &restoreResult);
+
+    if (messageResult == 0) {
+        Diagnostics::LogFormat(
+            "Reset mode: WM_REDLIGHT_RESTORE send failed or timed out (GetLastError=%lu).",
+            static_cast<unsigned long>(GetLastError()));
+        return false;
+    }
+
+    Diagnostics::LogFormat(
+        "Reset mode: WM_REDLIGHT_RESTORE succeeded with result=%s.",
+        restoreResult ? "TRUE" : "FALSE");
+    return restoreResult != FALSE;
 }
 
 void UpdateTrayIconTip(const char* tip) {
@@ -79,13 +252,18 @@ void UpdateTrayIconTip(const char* tip) {
 }
 
 void ToggleRedlight() {
+    Diagnostics::LogFormat("Toggle request: %s", g_displayFilter->isActive() ? "disable" : "enable");
     if (g_displayFilter->isActive()) {
         if (!g_displayFilter->disable()) {
-            OutputDebugStringA("RedLight: failed to disable red filter.\n");
+            Diagnostics::Log("Toggle result: disable failed.");
+        } else {
+            Diagnostics::Log("Toggle result: disable succeeded.");
         }
     } else {
         if (!g_displayFilter->enable()) {
-            OutputDebugStringA("RedLight: failed to enable red filter.\n");
+            Diagnostics::Log("Toggle result: enable failed.");
+        } else {
+            Diagnostics::Log("Toggle result: enable succeeded.");
         }
     }
 
@@ -100,6 +278,9 @@ void InitializeTrayIcon(HINSTANCE hInstance) {
     RegisterClass(&wc);
 
     HWND hwnd = CreateWindowEx(0, "TrayOnlyClass", "RedLight", 0, 0, 0, 0, 0, NULL, NULL, hInstance, NULL);
+    if (!hwnd) {
+        Diagnostics::LogFormat("CreateWindowEx failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
+    }
 
     nid.cbSize = sizeof(NOTIFYICONDATA);
     nid.hWnd = hwnd;
@@ -108,7 +289,9 @@ void InitializeTrayIcon(HINSTANCE hInstance) {
     nid.uCallbackMessage = WM_TRAYICON;
     nid.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_REDLIGHT_ICON));
     strcpy_s(nid.szTip, g_displayFilter->isActive() ? "RedLight ON" : "RedLight off");
-    Shell_NotifyIcon(NIM_ADD, &nid);
+    if (!Shell_NotifyIcon(NIM_ADD, &nid)) {
+        Diagnostics::LogFormat("Shell_NotifyIcon(NIM_ADD) failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
+    }
 }
 
 void ShowAboutDialog(HWND parent) {
@@ -149,6 +332,22 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
             ShowAboutDialog(hwnd);
         }
         break;
+
+    case WM_REDLIGHT_RESTORE:
+        Diagnostics::Log("External restore request received.");
+        if (!g_displayFilter->isActive()) {
+            Diagnostics::Log("External restore request: filter already inactive.");
+            return TRUE;
+        }
+
+        if (!g_displayFilter->disable()) {
+            Diagnostics::Log("External restore request: disable failed.");
+            return FALSE;
+        }
+
+        UpdateTrayIconTip("RedLight off");
+        Diagnostics::Log("External restore request: disable succeeded.");
+        return TRUE;
 
     case WM_DESTROY:
         Shell_NotifyIcon(NIM_DELETE, &nid);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,7 +296,7 @@ void InitializeTrayIcon(HINSTANCE hInstance) {
 
 void ShowAboutDialog(HWND parent) {
     char aboutText[512];
-    sprintf_s(aboutText, sizeof(aboutText), "RedLight v0.4.0-beta\n\ngithub.com/michaelmawhinney/redlight");
+    sprintf_s(aboutText, sizeof(aboutText), "RedLight v0.5.0-beta\n\ngithub.com/michaelmawhinney/redlight");
     const char* aboutTitle = "About";
 
     MessageBox(parent, aboutText, aboutTitle, MB_OK | MB_ICONINFORMATION);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 
 #include "GammaRampFilter.h"
+#include "MagnificationFilter.h"
 
 #define WM_TRAYICON (WM_USER + 1)
 #define IDI_REDLIGHT_ICON 100
@@ -10,9 +11,20 @@
 #define ID_TRAY_ABOUT 201
 #define ID_TRAY_EXIT 202
 
+namespace {
+
+MagnificationFilter g_magnificationFilter;
 GammaRampFilter g_gammaRampFilter;
 DisplayFilter* g_displayFilter = &g_gammaRampFilter;
 NOTIFYICONDATA nid = {};
+
+void LogBackendMessage(const char* message, const char* backendName) {
+    char buffer[256];
+    sprintf_s(buffer, sizeof(buffer), "RedLight: %s (%s)\n", message, backendName);
+    OutputDebugStringA(buffer);
+}
+
+}
 
 void ToggleRedlight();
 void UpdateTrayIconTip(const char* tip);
@@ -33,9 +45,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         return 1;
     }
 
-    if (!g_displayFilter->initialize()) {
-        CloseHandle(hMutex);
-        return 1;
+    if (g_magnificationFilter.initialize()) {
+        g_displayFilter = &g_magnificationFilter;
+        LogBackendMessage("using primary display backend", g_displayFilter->name());
+    } else {
+        OutputDebugStringA("RedLight: MagnificationFilter initialization failed; falling back to GammaRampFilter.\n");
+        if (!g_gammaRampFilter.initialize()) {
+            CloseHandle(hMutex);
+            return 1;
+        }
+        g_displayFilter = &g_gammaRampFilter;
+        LogBackendMessage("using fallback display backend", g_displayFilter->name());
     }
 
     InitializeTrayIcon(hInstance);
@@ -87,7 +107,7 @@ void InitializeTrayIcon(HINSTANCE hInstance) {
     nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
     nid.uCallbackMessage = WM_TRAYICON;
     nid.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_REDLIGHT_ICON));
-    strcpy_s(nid.szTip, "RedLight off");
+    strcpy_s(nid.szTip, g_displayFilter->isActive() ? "RedLight ON" : "RedLight off");
     Shell_NotifyIcon(NIM_ADD, &nid);
 }
 


### PR DESCRIPTION
## Summary

Merges the v0.5.0-beta RedLight work from the development fork back into the original repository.

## Highlights

- Adds Windows Magnification API as the preferred display backend
- Keeps legacy gamma-ramp backend as fallback
- Adds diagnostics logging at `%LOCALAPPDATA%\RedLight\redlight.log`
- Adds log rotation
- Adds recovery commands:
  - `RedLight.exe --restore`
  - `RedLight.exe --reset-display`
- Updates README, changelog, About dialog, version, and x64 release workflow

## Manual test notes

Tested on Windows 10 x64:

- RedLight builds
- About dialog shows v0.5.0-beta
- Tray toggle works
- Exit restores normal display
- `--restore` restores while tray app is active
- `--reset-display` restores while tray app is active
- `redlight.log` is created under `%LOCALAPPDATA%\RedLight\`
- Log rotation works
- Two-monitor test passed