### PR TITLE
Update GitHub Actions dependencies for Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
       run: cmake --build build --config Release
 
     - name: Archive Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: redlight
         path: build/Release/RedLight.exe


### PR DESCRIPTION
| Action                    | Recommended major | Latest shown | Node 24 support                                                                                                                   |
| ------------------------- | ----------------: | -----------: | --------------------------------------------------------------------------------------------------------------------------------- |
| `actions/checkout`        |             `@v6` |     `v6.0.2` | `v6` action metadata uses `runs: using: node24`; `v5` was the release that introduced Node 24 support. ([GitHub][1])              |
| `actions/upload-artifact` |             `@v7` |     `v7.0.1` | `v7` action metadata uses `runs: using: node24`; `v6` was the release that switched the default runtime to Node 24. ([GitHub][2]) |

[1]: https://github.com/marketplace/actions/checkout "Checkout · Actions · GitHub Marketplace · GitHub"
[2]: https://github.com/marketplace/actions/upload-a-build-artifact "Upload a Build Artifact · Actions · GitHub Marketplace · GitHub"