### PR TITLE
Add release checksum and unsigned app notice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,15 +36,25 @@ jobs:
     - name: Build
       run: cmake --build build --config Release
 
+    - name: Generate SHA-256 checksum
+      shell: pwsh
+      run: |
+        $hash = Get-FileHash build/Release/RedLight.exe -Algorithm SHA256
+        "$($hash.Hash.ToLower())  RedLight.exe" | Set-Content -Path build/Release/RedLight.exe.sha256 -Encoding ascii
+
     - name: Archive Artifacts
       uses: actions/upload-artifact@v7
       with:
         name: redlight
-        path: build/Release/RedLight.exe
+        path: |
+          build/Release/RedLight.exe
+          build/Release/RedLight.exe.sha256
 
     - name: Release and Upload Asset
       if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v3
       with:
-        files: build/Release/RedLight.exe
+        files: |
+          build/Release/RedLight.exe
+          build/Release/RedLight.exe.sha256
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Release and Upload Asset
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: build/Release/RedLight.exe
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ After starting RedLight, an icon will appear in the system tray.
 * This application may conflict with other apps/features that change display color, such as f.lux, Windows Night Light, HDR/color calibration settings, GPU color controls, or similar display-color tools. If you want to use RedLight, you should close or disable similar apps/features to avoid unexpected behavior.
 * RedLight is provided as-is and without any warranty of any kind. Although the code is simple and straightforward, you are still advised to use it at your own risk!
 
+## Windows Security Notice
+
+RedLight beta builds are currently unsigned. Because the executable is not code-signed, Windows or Microsoft Defender SmartScreen may show a warning before running it, especially the first time it is downloaded.
+
+This warning does not necessarily mean RedLight is malicious; it means Windows does not yet recognize the publisher or file reputation. RedLight is open source, so users who are concerned are encouraged to inspect the source code, build the app themselves, or verify the downloaded executable against the SHA-256 checksum published with the release.
+
+Do not run software you do not trust. RedLight is provided as-is and without warranty.
+
 ## Troubleshooting
 * Log file: `%LOCALAPPDATA%\RedLight\redlight.log`
 * Reset commands:


### PR DESCRIPTION
## Summary

Adds release polish for the v0.5.0-beta build by publishing a SHA-256 checksum alongside the release executable and documenting that beta builds are currently unsigned.

## Changes

- Updates the GitHub Actions release workflow to generate `RedLight.exe.sha256`
- Uploads both `RedLight.exe` and `RedLight.exe.sha256` as build artifacts
- Attaches both files to tagged GitHub releases
- Updates `softprops/action-gh-release` to the Node 24-compatible v3 action
- Adds a Windows security notice to the README explaining that unsigned beta builds may trigger OS/SmartScreen warnings
- Encourages users to inspect the source, build from source, or verify the downloaded executable against the published SHA-256 checksum
- Updates the changelog for the checksum and unsigned-build notice

## Manual test notes

- GitHub Actions build passes
- Release workflow generates `RedLight.exe`
- Release workflow generates `RedLight.exe.sha256`
- Release artifact upload includes both files
- README documents the unsigned beta warning and checksum verification path