### PR TITLE
Add Luma Red mode as the default Magnification backend red mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.5.1-beta] - 2026-05-18
+
+### Added
+- Added an optional Luma Red mode for the Magnification API backend.
+- Added tray menu options for switching between Strict Red and Luma Red.
+
+### Changed
+- Changed the Magnification API backend default red mode to Luma Red while keeping gamma-ramp fallback on Strict Red only.
+- Updated tray tooltip, about text, and diagnostics to show the active backend and red mode.
+- Documented Strict Red versus Luma Red behavior and the Magnification API requirement for Luma Red.
+- Updated README and changelog terminology to use "Luma Red" and "luma-weighted red" instead of "luminance-based" or "red luminance".
+
 ## [0.5.0-beta] - 2026-05-07
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(RedLight VERSION 0.5.0)
+project(RedLight VERSION 0.5.1)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # RedLight
-RedLight is a lightweight Windows tray application that applies a strict red-only display filter. It is not a translucent tint. The app runs from the system tray, allowing users to easily toggle the filter on and off with one click.
+RedLight is a lightweight Windows tray application that applies a red-only display filter. It is not a translucent tint. The app runs from the system tray, allowing users to easily toggle the filter on and off with one click.
 
 ## Features
 - **Toggle Red Filter**: Quickly enable or disable the red filter directly from the system tray.
 - **Minimal Resource Usage**: Runs quietly in the background with essentially no impact on system performance.
 
-## Visual Behavior
-RedLight is intended to transform display output as follows:
+## Red Modes
+Strict Red is the original red-channel-only mode and transforms display output as follows:
 - Black stays black.
 - White becomes pure red.
 - Red stays red.
 - Green and blue output are eliminated.
 
+Luma Red is the default mode when the Magnification API backend is active. It converts visible colors into red luma using BT.601-style luma weights:
+- Output red = `0.299R + 0.587G + 0.114B`.
+- Output green = `0`.
+- Output blue = `0`.
+
+Luma Red keeps the display red-only while making blue, green, and cyan UI elements visible as shades of red. It requires the Windows Magnification API backend because gamma ramps do not support cross-channel color mixing. If RedLight falls back to the gamma-ramp backend, RedLight starts in Strict Red and only Strict Red is available.
+
 ## Architecture
-v0.5.0-beta uses the Windows Magnification API full-screen color transform as the preferred backend.
-The legacy gamma-ramp backend is retained as a fallback.
+v0.5.1-beta uses the Windows Magnification API full-screen color transform as the preferred backend, with Luma Red as the default mode.
+The legacy gamma-ramp backend is retained as a Strict Red fallback.
 
 ## Installation
 To install RedLight, follow these steps:
@@ -27,6 +34,8 @@ After starting RedLight, an icon will appear in the system tray.
 * Left-click on the icon to toggle between red mode and normal mode.
 * Right-click the icon to access the following options:
   - **Toggle ON/off**: Enable or disable the red light filter.
+  - **Strict Red**: Use the original red-channel-only mode.
+  - **Luma Red**: Use the default luma-weighted red mode when the Magnification API backend is active.
   - **About**: Display information about the application.
   - **Exit**: Quit the application.
 

--- a/src/DisplayFilter.h
+++ b/src/DisplayFilter.h
@@ -1,5 +1,21 @@
 #pragma once
 
+enum class RedMode {
+    StrictRed,
+    LumaRed,
+};
+
+inline const char* RedModeDisplayName(RedMode mode) {
+    switch (mode) {
+    case RedMode::StrictRed:
+        return "Strict Red";
+    case RedMode::LumaRed:
+        return "Luma Red";
+    }
+
+    return "Unknown";
+}
+
 class DisplayFilter {
 public:
     virtual ~DisplayFilter() = default;
@@ -8,6 +24,9 @@ public:
     virtual bool enable() = 0;
     virtual bool disable() = 0;
     virtual bool isActive() const = 0;
+    virtual bool setRedMode(RedMode mode) = 0;
+    virtual RedMode redMode() const = 0;
+    virtual bool supportsRedMode(RedMode mode) const = 0;
     virtual void shutdown() = 0;
     virtual const char* name() const = 0;
 };

--- a/src/GammaRampFilter.cpp
+++ b/src/GammaRampFilter.cpp
@@ -91,6 +91,23 @@ bool GammaRampFilter::isActive() const {
     return active_;
 }
 
+bool GammaRampFilter::setRedMode(RedMode mode) {
+    if (mode == RedMode::StrictRed) {
+        return true;
+    }
+
+    Diagnostics::Log("GammaRampFilter: Luma Red requested but gamma ramps do not support cross-channel mixing; staying in Strict Red.");
+    return false;
+}
+
+RedMode GammaRampFilter::redMode() const {
+    return RedMode::StrictRed;
+}
+
+bool GammaRampFilter::supportsRedMode(RedMode mode) const {
+    return mode == RedMode::StrictRed;
+}
+
 void GammaRampFilter::shutdown() {
     if (!initialized_) {
         return;

--- a/src/GammaRampFilter.h
+++ b/src/GammaRampFilter.h
@@ -13,6 +13,9 @@ public:
     bool enable() override;
     bool disable() override;
     bool isActive() const override;
+    bool setRedMode(RedMode mode) override;
+    RedMode redMode() const override;
+    bool supportsRedMode(RedMode mode) const override;
     void shutdown() override;
     const char* name() const override;
 

--- a/src/MagnificationFilter.cpp
+++ b/src/MagnificationFilter.cpp
@@ -15,7 +15,7 @@ constexpr MAGCOLOREFFECT kIdentityEffect = {{
     {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
 }};
 
-constexpr MAGCOLOREFFECT kRedOnlyEffect = {{
+constexpr MAGCOLOREFFECT kStrictRedEffect = {{
     {1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     {0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
@@ -23,11 +23,33 @@ constexpr MAGCOLOREFFECT kRedOnlyEffect = {{
     {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
 }};
 
+constexpr MAGCOLOREFFECT kLumaRedEffect = {{
+    // MAGCOLOREFFECT uses input-channel rows and output-channel columns.
+    // Put luma weights in the red output column so green and blue never emit.
+    {0.299f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.587f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.114f, 0.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 1.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 0.0f, 1.0f},
+}};
+
+const MAGCOLOREFFECT& ColorEffectForMode(RedMode mode) {
+    switch (mode) {
+    case RedMode::StrictRed:
+        return kStrictRedEffect;
+    case RedMode::LumaRed:
+        return kLumaRedEffect;
+    }
+
+    return kStrictRedEffect;
+}
+
 }  // namespace
 
 MagnificationFilter::MagnificationFilter()
     : initialized_(false),
       active_(false),
+      redMode_(RedMode::LumaRed),
       restoreEffect_(kIdentityEffect),
       lastError_{} {}
 
@@ -72,12 +94,14 @@ bool MagnificationFilter::enable() {
         return true;
     }
 
-    if (!SetColorEffect(kRedOnlyEffect, "MagSetFullscreenColorEffect(red-only)")) {
+    char action[128];
+    sprintf_s(action, sizeof(action), "MagSetFullscreenColorEffect(%s)", RedModeDisplayName(redMode_));
+    if (!SetColorEffect(ColorEffectForMode(redMode_), action)) {
         return false;
     }
 
     active_ = true;
-    Diagnostics::LogFormat("%s enable succeeded.", kFilterName);
+    Diagnostics::LogFormat("%s enable succeeded using %s.", kFilterName, RedModeDisplayName(redMode_));
     return true;
 }
 
@@ -102,6 +126,32 @@ bool MagnificationFilter::disable() {
 
 bool MagnificationFilter::isActive() const {
     return active_;
+}
+
+bool MagnificationFilter::setRedMode(RedMode mode) {
+    if (mode == redMode_) {
+        return true;
+    }
+
+    if (active_) {
+        char action[128];
+        sprintf_s(action, sizeof(action), "MagSetFullscreenColorEffect(%s)", RedModeDisplayName(mode));
+        if (!SetColorEffect(ColorEffectForMode(mode), action)) {
+            return false;
+        }
+    }
+
+    redMode_ = mode;
+    Diagnostics::LogFormat("%s red mode set to %s.", kFilterName, RedModeDisplayName(redMode_));
+    return true;
+}
+
+RedMode MagnificationFilter::redMode() const {
+    return redMode_;
+}
+
+bool MagnificationFilter::supportsRedMode(RedMode mode) const {
+    return mode == RedMode::StrictRed || mode == RedMode::LumaRed;
 }
 
 void MagnificationFilter::shutdown() {

--- a/src/MagnificationFilter.h
+++ b/src/MagnificationFilter.h
@@ -14,6 +14,9 @@ public:
     bool enable() override;
     bool disable() override;
     bool isActive() const override;
+    bool setRedMode(RedMode mode) override;
+    RedMode redMode() const override;
+    bool supportsRedMode(RedMode mode) const override;
     void shutdown() override;
     const char* name() const override;
 
@@ -23,6 +26,7 @@ private:
 
     bool initialized_;
     bool active_;
+    RedMode redMode_;
     MAGCOLOREFFECT restoreEffect_;
     char lastError_[256];
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,8 @@
 #define ID_TRAY_TOGGLE 200
 #define ID_TRAY_ABOUT 201
 #define ID_TRAY_EXIT 202
+#define ID_TRAY_MODE_STRICT_RED 203
+#define ID_TRAY_MODE_LUMA_RED 204
 
 namespace {
 
@@ -28,7 +30,9 @@ bool ResetDisplay();
 bool RequestRunningInstanceRestore(bool* handled);
 void ToggleRedlight();
 void UpdateTrayIconTip(const char* tip);
+void RefreshTrayIconTip();
 void InitializeTrayIcon(HINSTANCE hInstance);
+void SetRedModeFromTray(RedMode mode);
 void ShowAboutDialog(HWND parent);
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
@@ -68,7 +72,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     if (g_magnificationFilter.initialize()) {
         g_displayFilter = &g_magnificationFilter;
-        Diagnostics::LogFormat("Selected backend: %s", g_displayFilter->name());
+        Diagnostics::LogFormat("Selected backend: %s; red mode: %s", g_displayFilter->name(), RedModeDisplayName(g_displayFilter->redMode()));
     } else {
         Diagnostics::Log("MagnificationFilter initialization failed; falling back to GammaRampFilter.");
         if (!g_gammaRampFilter.initialize()) {
@@ -80,7 +84,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             return 1;
         }
         g_displayFilter = &g_gammaRampFilter;
-        Diagnostics::LogFormat("Selected backend: %s", g_displayFilter->name());
+        Diagnostics::LogFormat("Selected backend: %s; red mode: %s", g_displayFilter->name(), RedModeDisplayName(g_displayFilter->redMode()));
     }
 
     Diagnostics::LogFormat("Monitor count: %d", GetSystemMetrics(SM_CMONITORS));
@@ -248,11 +252,27 @@ bool RequestRunningInstanceRestore(bool* handled) {
 
 void UpdateTrayIconTip(const char* tip) {
     strcpy_s(nid.szTip, sizeof(nid.szTip), tip);
-    Shell_NotifyIcon(NIM_MODIFY, &nid);
+    if (!Shell_NotifyIcon(NIM_MODIFY, &nid)) {
+        Diagnostics::LogFormat("Shell_NotifyIcon(NIM_MODIFY) failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
+    }
+}
+
+void RefreshTrayIconTip() {
+    char tip[sizeof(nid.szTip)];
+    sprintf_s(tip,
+        sizeof(tip),
+        "RedLight %s - %s - %s",
+        g_displayFilter->isActive() ? "ON" : "off",
+        g_displayFilter->name(),
+        RedModeDisplayName(g_displayFilter->redMode()));
+    UpdateTrayIconTip(tip);
 }
 
 void ToggleRedlight() {
-    Diagnostics::LogFormat("Toggle request: %s", g_displayFilter->isActive() ? "disable" : "enable");
+    Diagnostics::LogFormat("Toggle request: %s (%s, %s)",
+        g_displayFilter->isActive() ? "disable" : "enable",
+        g_displayFilter->name(),
+        RedModeDisplayName(g_displayFilter->redMode()));
     if (g_displayFilter->isActive()) {
         if (!g_displayFilter->disable()) {
             Diagnostics::Log("Toggle result: disable failed.");
@@ -267,7 +287,7 @@ void ToggleRedlight() {
         }
     }
 
-    UpdateTrayIconTip(g_displayFilter->isActive() ? "RedLight ON" : "RedLight off");
+    RefreshTrayIconTip();
 }
 
 void InitializeTrayIcon(HINSTANCE hInstance) {
@@ -288,15 +308,49 @@ void InitializeTrayIcon(HINSTANCE hInstance) {
     nid.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
     nid.uCallbackMessage = WM_TRAYICON;
     nid.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_REDLIGHT_ICON));
-    strcpy_s(nid.szTip, g_displayFilter->isActive() ? "RedLight ON" : "RedLight off");
+    sprintf_s(nid.szTip,
+        sizeof(nid.szTip),
+        "RedLight %s - %s - %s",
+        g_displayFilter->isActive() ? "ON" : "off",
+        g_displayFilter->name(),
+        RedModeDisplayName(g_displayFilter->redMode()));
     if (!Shell_NotifyIcon(NIM_ADD, &nid)) {
         Diagnostics::LogFormat("Shell_NotifyIcon(NIM_ADD) failed (GetLastError=%lu).", static_cast<unsigned long>(GetLastError()));
     }
 }
 
+void SetRedModeFromTray(RedMode mode) {
+    Diagnostics::LogFormat("Red mode request: %s -> %s (%s)",
+        RedModeDisplayName(g_displayFilter->redMode()),
+        RedModeDisplayName(mode),
+        g_displayFilter->name());
+
+    if (!g_displayFilter->supportsRedMode(mode)) {
+        Diagnostics::LogFormat("%s does not support %s; keeping %s.",
+            g_displayFilter->name(),
+            RedModeDisplayName(mode),
+            RedModeDisplayName(g_displayFilter->redMode()));
+        RefreshTrayIconTip();
+        return;
+    }
+
+    if (!g_displayFilter->setRedMode(mode)) {
+        Diagnostics::LogFormat("Red mode change to %s failed.", RedModeDisplayName(mode));
+    } else {
+        Diagnostics::LogFormat("Red mode change to %s succeeded.", RedModeDisplayName(g_displayFilter->redMode()));
+    }
+
+    RefreshTrayIconTip();
+}
+
 void ShowAboutDialog(HWND parent) {
     char aboutText[512];
-    sprintf_s(aboutText, sizeof(aboutText), "RedLight v0.5.0-beta\n\ngithub.com/michaelmawhinney/redlight");
+    sprintf_s(aboutText,
+        sizeof(aboutText),
+        "RedLight v0.5.1-beta\n\nBackend: %s\nRed mode: %s%s\n\ngithub.com/michaelmawhinney/redlight",
+        g_displayFilter->name(),
+        RedModeDisplayName(g_displayFilter->redMode()),
+        g_displayFilter->supportsRedMode(RedMode::LumaRed) ? "" : "\nLuma Red requires the Magnification API backend.");
     const char* aboutTitle = "About";
 
     MessageBox(parent, aboutText, aboutTitle, MB_OK | MB_ICONINFORMATION);
@@ -310,7 +364,15 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
             GetCursorPos(&pt);
             HMENU hMenu = CreatePopupMenu();
             if (hMenu) {
+                const UINT strictFlags = MF_STRING | (g_displayFilter->redMode() == RedMode::StrictRed ? MF_CHECKED : MF_UNCHECKED);
+                const UINT lumaFlags = MF_STRING
+                    | (g_displayFilter->redMode() == RedMode::LumaRed ? MF_CHECKED : MF_UNCHECKED)
+                    | (g_displayFilter->supportsRedMode(RedMode::LumaRed) ? MF_ENABLED : MF_GRAYED);
                 AppendMenu(hMenu, MF_STRING, ID_TRAY_TOGGLE, TEXT("Toggle ON/off"));
+                AppendMenu(hMenu, MF_SEPARATOR, 0, NULL);
+                AppendMenu(hMenu, strictFlags, ID_TRAY_MODE_STRICT_RED, TEXT("Strict Red"));
+                AppendMenu(hMenu, lumaFlags, ID_TRAY_MODE_LUMA_RED, TEXT("Luma Red"));
+                AppendMenu(hMenu, MF_SEPARATOR, 0, NULL);
                 AppendMenu(hMenu, MF_STRING, ID_TRAY_ABOUT, TEXT("About"));
                 AppendMenu(hMenu, MF_STRING, ID_TRAY_EXIT, TEXT("Exit"));
                 SetForegroundWindow(hwnd);
@@ -325,6 +387,10 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
     case WM_COMMAND:
         if (LOWORD(wParam) == ID_TRAY_TOGGLE) {
             ToggleRedlight();
+        } else if (LOWORD(wParam) == ID_TRAY_MODE_STRICT_RED) {
+            SetRedModeFromTray(RedMode::StrictRed);
+        } else if (LOWORD(wParam) == ID_TRAY_MODE_LUMA_RED) {
+            SetRedModeFromTray(RedMode::LumaRed);
         } else if (LOWORD(wParam) == ID_TRAY_EXIT) {
             Shell_NotifyIcon(NIM_DELETE, &nid);
             PostQuitMessage(0);
@@ -345,7 +411,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
             return FALSE;
         }
 
-        UpdateTrayIconTip("RedLight off");
+        RefreshTrayIconTip();
         Diagnostics::Log("External restore request: disable succeeded.");
         return TRUE;
 


### PR DESCRIPTION
## Summary

Adds a new Luma Red display mode that keeps the display red-only while preserving more visual information from blue, green, and cyan UI elements.

Luma Red is now the default mode when the Magnification API backend is active. The original red-channel-only behavior remains available as Strict Red.

## Changes

- Add `RedMode` support with `StrictRed` and `LumaRed`
- Add a Magnification API color matrix for Luma Red using BT.601-style luma weights:
  - output red = `0.299R + 0.587G + 0.114B`
  - output green = `0`
  - output blue = `0`
- Make Luma Red the default for the Magnification API backend
- Keep gamma-ramp fallback Strict Red only because gamma ramps do not support cross-channel color mixing
- Add tray menu options for switching between Strict Red and Luma Red
- Update tray tooltip, About dialog, diagnostics, README, changelog, and project version for `0.5.1-beta`

## Testing

- `git diff --check` passed
- Build was not run in Codex because the environment did not have CMake or a Windows runtime

## Manual Windows test checklist

- Start RedLight and confirm tray/about/logs show Luma Red when the Magnification backend is active
- Left-click the tray icon and confirm Luma Red is applied by default
- Switch between Luma Red and Strict Red while the filter is off
- Switch between Luma Red and Strict Red while the filter is on
- Confirm blue, green, and cyan UI elements remain visible as shades of red in Luma Red
- Confirm Strict Red preserves the original red-channel-only behavior
- Exit the app and confirm the display is restored
- Run `RedLight.exe --restore` and confirm the display resets correctly

Closes #12.